### PR TITLE
feat : 자막 live 없애고 final만 남기기

### DIFF
--- a/src/components/recording/TranscriptArea.tsx
+++ b/src/components/recording/TranscriptArea.tsx
@@ -1,22 +1,19 @@
 import { useEffect, useRef } from 'react';
 import type { TranscriptEntry } from '@/types/recording';
-import participant1Image from '@/assets/avatars/participant1.png';
 import TranscriptItem from './TranscriptItem';
 
 interface TranscriptAreaProps {
   entries: TranscriptEntry[];
-  liveText?: string;
-  liveTimestamp?: string;
 }
 
-export default function TranscriptArea({ entries, liveText, liveTimestamp }: TranscriptAreaProps) {
+export default function TranscriptArea({ entries }: TranscriptAreaProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [entries, liveText]);
+  }, [entries]);
 
-  if (entries.length === 0 && !liveText) {
+  if (entries.length === 0) {
     return (
       <div className="px-[71px] pt-[38px]">
         <p className="text-[16px] leading-normal text-[#959595]">
@@ -33,28 +30,6 @@ export default function TranscriptArea({ entries, liveText, liveTimestamp }: Tra
       {entries.map((entry, index) => (
         <TranscriptItem key={index} entry={entry} />
       ))}
-      {liveText && (
-        <div className="flex flex-col gap-[8px]">
-          <p className="text-[16px] leading-normal font-bold text-[#c4c4c4]">
-            {liveTimestamp}
-          </p>
-          <div className="flex gap-[16px]">
-            <div className="flex shrink-0 flex-col items-center gap-[2px]">
-              <img
-                src={participant1Image}
-                alt="참석자 1"
-                className="size-[30px] rounded-full object-cover"
-              />
-              <span className="text-[10px] font-medium text-[#4A90D9]">
-                참석자 1
-              </span>
-            </div>
-            <p className="text-[14px] leading-normal font-medium whitespace-pre-wrap text-[#4A90D9]">
-              {liveText}
-            </p>
-          </div>
-        </div>
-      )}
       <div ref={bottomRef} />
     </div>
   );

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -11,19 +11,16 @@ interface UseSocketReturn {
 }
 
 export function useSocket(
-  onSubtitleLive: (text: string) => void,
   onSubtitleFinal: (text: string) => void,
 ): UseSocketReturn {
   const socketRef = useRef<SocketIOClient.Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
 
-  const onSubtitleLiveRef = useRef(onSubtitleLive);
   const onSubtitleFinalRef = useRef(onSubtitleFinal);
 
   useEffect(() => {
-    onSubtitleLiveRef.current = onSubtitleLive;
     onSubtitleFinalRef.current = onSubtitleFinal;
-  }, [onSubtitleLive, onSubtitleFinal]);
+  }, [onSubtitleFinal]);
 
   const connect = useCallback(() => {
     if (socketRef.current?.connected) return;
@@ -42,12 +39,6 @@ export function useSocket(
     socket.on('disconnect', (reason) => {
       console.log('[Socket] 연결 해제:', reason);
       setIsConnected(false);
-    });
-
-    socket.on('stt:subtitle_live', (...args: unknown[]) => {
-      const text = args[0] as string;
-      console.log('[Socket] subtitle_live:', text);
-      onSubtitleLiveRef.current(text);
     });
 
     socket.on('stt:subtitle_final', (...args: unknown[]) => {

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -32,8 +32,6 @@ function formatElapsed(ms: number): string {
 
 export default function RecordingPage() {
   const [entries, setEntries] = useState<TranscriptEntry[]>([]);
-  const [liveText, setLiveText] = useState('');
-  const [liveTimestamp, setLiveTimestamp] = useState('');
   const [isRecording, setIsRecording] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
 
@@ -50,12 +48,6 @@ export default function RecordingPage() {
   }, [isPaused]);
 
   const { sendAudio, connect, disconnect } = useSocket(
-    // onSubtitleLive
-    (text) => {
-      setLiveText(text);
-      setLiveTimestamp((prev) => prev || formatElapsed(getElapsed()));
-    },
-    // onSubtitleFinal
     (text) => {
       const elapsed = getElapsed();
       setEntries((prev) => [
@@ -67,8 +59,6 @@ export default function RecordingPage() {
           text,
         },
       ]);
-      setLiveText('');
-      setLiveTimestamp('');
     },
   );
 
@@ -86,7 +76,6 @@ export default function RecordingPage() {
     setIsRecording(true);
     setIsPaused(false);
     setEntries([]);
-    setLiveText('');
   }, [connect, sendAudio]);
 
   const handleTogglePause = useCallback(() => {
@@ -109,7 +98,6 @@ export default function RecordingPage() {
     disconnect();
     setIsRecording(false);
     setIsPaused(false);
-    setLiveText('');
   }, [disconnect]);
 
   const handleCancel = useCallback(() => {
@@ -119,7 +107,6 @@ export default function RecordingPage() {
     setIsRecording(false);
     setIsPaused(false);
     setEntries([]);
-    setLiveText('');
   }, [disconnect]);
 
   return (
@@ -138,11 +125,7 @@ export default function RecordingPage() {
         {/* 하단 분할 영역 */}
         <div className="flex min-h-0 flex-1">
           <div className="flex-1 overflow-y-auto">
-            <TranscriptArea
-              entries={entries}
-              liveText={liveText}
-              liveTimestamp={liveTimestamp}
-            />
+            <TranscriptArea entries={entries} />
           </div>
           <RightPanel memos={[]} defaultTab="summary" />
         </div>


### PR DESCRIPTION
## 기능 설명

<img width="893" height="434" alt="스크린샷 2026-03-15 오후 4 08 16" src="https://github.com/user-attachments/assets/959fa748-082e-427c-926d-8e1db90d1133" />

## 작업내용

실시간 자막 없애고 최종 자막만 나오게 했습니다.

## 메모

백엔드가 응답값 저렇게 와서 일단 백엔드에서 수정하고 봐야될듯..

## 연관 이슈

close #12 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 리뷰어 설정을 했는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
